### PR TITLE
fix: return code 500 instead of 400 remote api call fails

### DIFF
--- a/lib/controllers/axfr/axfr-check-get-ctrl.js
+++ b/lib/controllers/axfr/axfr-check-get-ctrl.js
@@ -29,7 +29,7 @@ const onlineAxfrCheck = (req, res) => {
     .catch(apiError => {
       const err = errorUtil.makeError(apiError, 500);
       res
-        .status(400)
+        .status(500)
         .send(err)
         .end();
     });

--- a/lib/controllers/axfr/dns-check-get-ctrl.js
+++ b/lib/controllers/axfr/dns-check-get-ctrl.js
@@ -24,7 +24,7 @@ const onlineDnsCheck = (req, res) => {
     .catch(apiError => {
       const err = errorUtil.makeError(apiError, 500);
       res
-        .status(400)
+        .status(500)
         .send(err)
         .end();
     });

--- a/lib/controllers/axfr/domain-check-get-ctrl.js
+++ b/lib/controllers/axfr/domain-check-get-ctrl.js
@@ -31,7 +31,7 @@ const onlineDomainCheck = (req, res) => {
     .catch(apiError => {
       const err = errorUtil.makeError(apiError, 500);
       res
-        .status(400)
+        .status(500)
         .send(err)
         .end();
     });

--- a/lib/controllers/axfr/ssl-check-get-ctrl.js
+++ b/lib/controllers/axfr/ssl-check-get-ctrl.js
@@ -30,7 +30,7 @@ const onlineSslCheck = (req, res) => {
     .catch(apiError => {
       const err = errorUtil.makeError(apiError, 500);
       res
-        .status(400)
+        .status(500)
         .send(err)
         .end();
     });


### PR DESCRIPTION
- All the APIs were returning code 400 instead of 500 if the remote API had an error.